### PR TITLE
bug: fix the bug of add and remove the picture multiple times.

### DIFF
--- a/javascript/img-stream/app/components/Drop/index.js
+++ b/javascript/img-stream/app/components/Drop/index.js
@@ -38,7 +38,9 @@ export default class Drop extends Component {
 
  
 
-  remove = () => {
+  remove = (event) => {
+    // bug fix: stop the propagation to the click method.
+    event.stopPropagation();
     this.setState({src: ''})
   }
 


### PR DESCRIPTION
If we click the add and remove icon multiple times, the picture may not display in the dotted box sometimes. You can have some tries to reproduce this issue. It seems that the event bubble happening on the remove icon bubbles to the click method to cause this problem. 